### PR TITLE
Remove team and user mentions from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # code owners
-* @cloudbees-io-gha/unifyciworkstream
+*


### PR DESCRIPTION
## Changes

Removed team and individual user mentions from repos we don't own

### Details
- Removed @cloudbees-io-gha/unifyciworkstream from CODEOWNERS